### PR TITLE
D01BD36C-E447-4215-BB22-30C9857279D4

### DIFF
--- a/docs/todos.org
+++ b/docs/todos.org
@@ -11,7 +11,8 @@
 :PROPERTIES:
 :ID:       3A2C430B-2675-48B4-B214-DD0F9BF8D1FC
 :END:
-** TODO We don't have the machinery in place to prove (implies (and (or p q) r) (or (and p r) (and q r))) -- probably disjunctive proof has to break out of the direct proof code and take an input specifying the disjunct to prove /somehow/
+** DONE We don't have the machinery in place to prove (implies (and (or p q) r) (or (and p r) (and q r))) -- probably disjunctive proof has to break out of the direct proof code and take an input specifying the disjunct to prove /somehow/
+CLOSED: [2022-03-29 Tue 00:04]
 :PROPERTIES:
 :ID:       CB509F0E-E0C6-462B-973D-14404D244F86
 :END:
@@ -19,12 +20,14 @@
 :PROPERTIES:
 :ID:       E57D10DC-D223-4BA5-8333-CACA7099E820
 :END:
-** TODO No way to prove (implies (not (not (not p))) (not p)) without support for using other theorems or arbitrary established proofs
+** DONE No way to prove (implies (not (not (not p))) (not p)) without support for using other theorems or arbitrary established proofs
+CLOSED: [2022-03-28 Mon 23:56]
 :PROPERTIES:
 :ID:       24F7DEFA-436F-47BB-A6E4-478B14077952
 :END:
 * Version 1                                                              :v1:
-** TODO support =assert= which allows the user to prove an arbitrary formula and add it based on current relevant premises
+** DONE support =assert= which allows the user to prove an arbitrary formula and add it based on current relevant premises
+CLOSED: [2022-03-28 Mon 23:56]
 :PROPERTIES:
 :ID:       D01BD36C-E447-4215-BB22-30C9857279D4
 :END:

--- a/src/clj/logos/main.clj
+++ b/src/clj/logos/main.clj
@@ -130,8 +130,6 @@
                      fnct
                      :args premise-idxs))]
     (case operation
-      "assert"
-      (function #'premise/add-premise)
       "->E"
       (function #'premise/conditional-elimination)
       "&E"
@@ -144,6 +142,10 @@
       (function #'premise/universal-elimination)
       "EE"
       (function #'premise/existential-elimination))))
+
+(defn assert-formula-to-proof [proof formula-string]
+  (let [formula (f/read-formula formula-string)]
+    (one-step proof #'goal/assert :args formula)))
 
 (defn execute-existential-proof [proof substituent-string]
   (let [substituents (read-string (format "[%s]" substituent-string))]
@@ -158,9 +160,13 @@
                            (filter #(not= "" %)))]
     (cond (= (count split-command) 1)
           (execute-goal-operation proof (first split-command))
-          (= (first split-command) "EP")
           ;; Existential Proof
+          (= (first split-command) "EP")
           (execute-existential-proof
+           proof (string/join " " (rest split-command)))
+          ;; Assert
+          (= (first split-command) "ASSERT")
+          (assert-formula-to-proof
            proof (string/join " " (rest split-command)))
           (> (count split-command) 1)
           (execute-premise-operation proof split-command)

--- a/src/clj/logos/proof/goal.clj
+++ b/src/clj/logos/proof/goal.clj
@@ -168,6 +168,22 @@
                   edge-index new-edges))))
       proof)))
 
+(defn assert [proof formula]
+  (let [current-idx (get proof ::proof/current-problem)
+        new-idx     (proof/get-new-problem-idx proof)
+        new-problem (proof/new-problem
+                     [] formula new-idx :type ::proof/assert)
+        new-edges   (proof/add-edges-to-edge-index
+                     (get proof ::proof/edges) [[current-idx new-idx]])]
+    (-> proof
+        (update
+         ::proof/problems (fn [pf] (assoc pf new-idx new-problem)))
+        (assoc ::proof/current-problem new-idx
+               ::proof/edges new-edges))))
+
+
+
+
 (defn id-reflexivity [proof] nil)
 
 (defn modal-proof [proof] nil)

--- a/src/cljs/logos/views.cljs
+++ b/src/cljs/logos/views.cljs
@@ -86,7 +86,7 @@
 (defn clear-proof-button [clear-type]
   (let [style (case clear-type
                 :clear  "button is-danger"
-                :done   "button is-info")
+                :done   "button is-success")
         text  (case clear-type
                 :clear "Clear Proof"
                 :done  "Next Proof")]
@@ -198,6 +198,7 @@
                 proof @(rf/subscribe [::subs/proof])]
             (rf/dispatch [::events/hide-modal id])
             (clear-all-checkboxes)
+            (reset! input-atom "")
             (next-proof command proof)))}
        "Submit Command"]
       ]]))
@@ -208,6 +209,7 @@
 (def disjunction-elimination-atom (r/atom ""))
 (def bottom-introduction-atom (r/atom ""))
 (def existential-elimination-atom (r/atom ""))
+(def assert-atom (r/atom ""))
 (def universal-elimination-atom (r/atom ""))
 
 (defn next-command-section
@@ -221,8 +223,9 @@
         proof-formulas proof-string false true]]
       [:div
        {:class "column is-one-quarter"}
-       [:h3 {:class "title is-h3"} "Goal Operations"]
-       [:div.buttons
+       [:div
+        {:class "tile is-vertical is-child box"}
+        [:h3 {:class "title is-h3"} "Goal Operations"]
         (map (fn [[command label]]
                [:div
                 [:button
@@ -237,11 +240,15 @@
               ["VP"  "Disjunctive Proof"]
               ["~P"  "Negative Proof"]
               ["UP"  "Universal Proof"]])
-        [proof-step-input-button "Existential Proof" "ep" "EP" ep-atom false true]]]
+        [proof-step-input-button
+         "Assert" "assert" "ASSERT" assert-atom false true]
+        [proof-step-input-button
+         "Existential Proof" "ep" "EP" ep-atom false true]]]
       [:div
        {:class "column is-one-quarter"}
-       [:h3 {:class "title is-h3"} "Premise Operations"]
-       [:div.buttons
+       [:div
+        {:class "tile is-vertical is-child box"}
+        [:h3 {:class "title is-h3"} "Premise Operations"]
         (map (fn [[label id command atom with-vars?]]
                [proof-step-input-button
                 label id command atom true with-vars? proof-formulas proof-string])

--- a/test/logos/proof_goal_test.clj
+++ b/test/logos/proof_goal_test.clj
@@ -23,13 +23,16 @@
          ::proof/problems {0 {::proof/premises [0]
                               ::proof/goal     r
                               ::proof/id 0
+                              ::proof/type ::proof/proof
                               ::proof/status ::proof/open}
                            1 {::proof/premises [1]
                               ::proof/goal     p
                               ::proof/id 1
+                              ::proof/type ::proof/proof
                               ::proof/status ::proof/open}}
          ::proof/edges {0 {::proof/to [1]}
                         1 {::proof/from [0]}}})
+
 (deftest test-conditional-proofs
   (are [start-proof result-proof]
       (= (goal/conditional-proof start-proof)
@@ -40,8 +43,8 @@
        ::proof/problems        {0 {::proof/premises []
                                    ::proof/goal   p->q
                                    ::proof/id        0
-                                   ::proof/status
-                                   ::proof/open}}
+                                   ::proof/type ::proof/proof
+                                   ::proof/status ::proof/open}}
        ::proof/edges           {}}
       {::proof/current-problem 1
        ::proof/premises        {0 {::proof/formula p
@@ -50,13 +53,13 @@
        ::proof/problems       {0 {::proof/premises []
                                   ::proof/goal   p->q
                                   ::proof/id        0
-                                  ::proof/status
-                                  ::proof/open}
+                                  ::proof/type ::proof/proof
+                                  ::proof/status ::proof/open}
                                1 {::proof/premises [0]
                                   ::proof/goal q
                                   ::proof/id 1
-                                  ::proof/status
-                                  ::proof/open}}
+                                  ::proof/type ::proof/proof
+                                  ::proof/status ::proof/open}}
        ::proof/edges {0 {::proof/to [1]}
                       1 {::proof/from [0]}}}
       ;;: Case 2
@@ -67,13 +70,13 @@
        ::proof/problems        {0 {::proof/premises [0]
                                    ::proof/goal      q
                                    ::proof/id        0
-                                   ::proof/status
-                                   ::proof/open}
+                                   ::proof/type ::proof/proof
+                                   ::proof/status ::proof/open}
                                 1 {::proof/premises []
                                    ::proof/goal     p->q
                                    ::proof/id        1
-                                   ::proof/status
-                                   ::proof/open}}
+                                   ::proof/type ::proof/proof
+                                   ::proof/status ::proof/open}}
        ::proof/edges           {0 {::proof/to [1]}
                                 1 {::proof/from [0]}}}
       {::proof/current-problem 2
@@ -86,18 +89,18 @@
        ::proof/problems        {0 {::proof/premises [0]
                                    ::proof/goal      q
                                    ::proof/id        0
-                                   ::proof/status
-                                   ::proof/open}
+                                   ::proof/type ::proof/proof
+                                   ::proof/status ::proof/open}
                                 1 {::proof/premises []
                                    ::proof/goal     p->q
                                    ::proof/id        1
-                                   ::proof/status
-                                   ::proof/open}
+                                   ::proof/type ::proof/proof
+                                   ::proof/status ::proof/open}
                                 2 {::proof/premises [1]
                                    ::proof/goal      q
                                    ::proof/id        2
-                                   ::proof/status
-                                   ::proof/open}
+                                   ::proof/type ::proof/proof
+                                   ::proof/status ::proof/open}
                                 }
        ::proof/edges           {0 {::proof/to [1]}
                                 1 {::proof/from [0]
@@ -111,13 +114,13 @@
        ::proof/problems        {0 {::proof/premises [0]
                                    ::proof/goal      q
                                    ::proof/id        0
-                                   ::proof/status
-                                   ::proof/open}
+                                   ::proof/type ::proof/proof
+                                   ::proof/status ::proof/open}
                                 1 {::proof/premises []
                                    ::proof/goal     p->q
                                    ::proof/id        1
-                                   ::proof/status
-                                   ::proof/open}}
+                                   ::proof/type ::proof/proof
+                                   ::proof/status ::proof/open}}
        ::proof/edges           {0 {::proof/to [1]}
                                 1 {::proof/from [0]}}}
       {::proof/current-problem 0
@@ -127,13 +130,13 @@
        ::proof/problems        {0 {::proof/premises [0]
                                    ::proof/goal      q
                                    ::proof/id        0
-                                   ::proof/status
-                                   ::proof/open}
+                                   ::proof/type ::proof/proof
+                                   ::proof/status ::proof/open}
                                 1 {::proof/premises []
                                    ::proof/goal     p->q
                                    ::proof/id        1
-                                   ::proof/status
-                                   ::proof/open}}
+                                   ::proof/type ::proof/proof
+                                   ::proof/status ::proof/open}}
        ::proof/edges           {0 {::proof/to [1]}
                                 1 {::proof/from [0]}}}))
 
@@ -151,10 +154,13 @@
        ::proof/problems {0 {::proof/premises [0]
                             ::proof/goal     r
                             ::proof/id 0
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/closed}
                          1 {::proof/premises [1]
                             ::proof/goal     p
                             ::proof/id 1
+
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/closed}}
        ::proof/edges {0 {::proof/to [1]}
                       1 {::proof/from [0]}}}
@@ -167,10 +173,12 @@
        ::proof/problems {0 {::proof/premises [0]
                             ::proof/goal     r
                             ::proof/id 0
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/open}
                          1 {::proof/premises [1]
                             ::proof/goal     p
                             ::proof/id 1
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/open}}
        ::proof/edges {0 {::proof/to [1]}
                       1 {::proof/from [0]}}}
@@ -182,10 +190,12 @@
        ::proof/problems {0 {::proof/premises [0 1]
                             ::proof/goal     r
                             ::proof/id 0
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/closed}
                          1 {::proof/premises [1]
                             ::proof/goal     p
                             ::proof/id 1
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/closed}}
        ::proof/edges {0 {::proof/to [1]}
                       1 {::proof/from [0]}}}
@@ -205,6 +215,7 @@
                          1 {::proof/premises []
                             ::proof/goal p
                             ::proof/id  1
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/closed}}
        ::proof/edges {0 {::proof/to [1 2]}
                       1 {::proof/from [0]}
@@ -221,14 +232,17 @@
                                           ["!P"]
                                           [:implies ["!Q"] ["!P"]]]
                             ::proof/id 0
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/open}
                          1 {::proof/premises [0]
                             ::proof/goal [:implies ["!Q"] ["!P"]]
                             ::proof/id 1
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/open}
                          2 {::proof/premises [1]
                             ::proof/goal ["!P"]
                             ::proof/id 2
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/open}}
        ::proof/edges
        {0 {::proof/to [1]}
@@ -245,14 +259,17 @@
                                           ["!P"]
                                           [:implies ["!Q"] ["!P"]]]
                             ::proof/id 0
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/closed}
                          1 {::proof/premises [0]
                             ::proof/goal [:implies ["!Q"] ["!P"]]
                             ::proof/id 1
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/closed}
                          2 {::proof/premises [1]
                             ::proof/goal ["!P"]
                             ::proof/id 2
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/closed}}
        ::proof/edges
        {0 {::proof/to [1]}
@@ -266,6 +283,7 @@
        ::proof/problems {0 {::proof/premises [0]
                             ::proof/goal q
                             ::proof/id 0
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/open}}
        ::proof/edges {}}
       {::proof/current-problem nil
@@ -274,9 +292,94 @@
        ::proof/problems {0 {::proof/premises [0]
                             ::proof/goal q
                             ::proof/id 0
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/closed}}
        ::proof/edges {}}
 
+      ;; Case 6
+      {::proof/current-problem 1
+       ::proof/premises {0 {::proof/formula ::formula/bottom
+                            ::proof/justification ::proof/assertion}
+                         1 {::proof/formula ["!A"]
+                            ::proof/justification ::proof/hypothesis}}
+       ::proof/problems {0 {::proof/premises [0]
+                            ::proof/goal q
+                            ::proof/id 0
+                            ::proof/type ::proof/proof
+                            ::proof/status ::proof/open}
+                         1 {::proof/premises [1]
+                            ::proof/goal ["!A"]
+                            ::proof/id 1
+                            ::proof/status ::proof/open
+                            ::proof/type   ::proof/assert}}
+       ::proof/edges {0 {::proof/to [1]}
+                      1 {::proof/from[0]}}}
+      {::proof/current-problem 0
+       ::proof/premises {0 {::proof/formula ::formula/bottom
+                            ::proof/justification ::proof/assertion}
+                         1 {::proof/formula ["!A"]
+                            ::proof/justification ::proof/hypothesis}
+                         2 {::proof/formula ["!A"]
+                            ::proof/justification ::proof/proved}}
+       ::proof/problems {0 {::proof/premises [0 2]
+                            ::proof/goal q
+                            ::proof/id 0
+                            ::proof/type ::proof/proof
+                            ::proof/status ::proof/open}
+                         1 {::proof/premises [1]
+                            ::proof/goal ["!A"]
+                            ::proof/id 1
+                            ::proof/status ::proof/closed
+                            ::proof/type   ::proof/assert}}
+       ::proof/edges {0 {::proof/to [1]}
+                      1 {::proof/from[0]}}}
+      ;; Case 7
+      {::proof/current-problem 1
+       ::proof/premises {0 {::proof/formula ::formula/bottom
+                            ::proof/justification ::proof/assertion}
+                         1 {::proof/formula ["!A"]
+                            ::proof/justification ::proof/hypothesis}}
+       ::proof/problems {0 {::proof/premises [0]
+                            ::proof/goal q
+                            ::proof/id 0
+                            ::proof/type ::proof/proof
+                            ::proof/status ::proof/open}
+                         1 {::proof/premises [1]
+                            ::proof/goal ["!A"]
+                            ::proof/id 1
+                            ::proof/status ::proof/open
+                            ::proof/type   ::proof/assert}
+                         2 {::proof/premises [1]
+                            ::proof/id 2
+                            ::proof/status ::proof/open
+                            ::proof/type   ::proof/proof}}
+       ::proof/edges {0 {::proof/to [1 2]}
+                      1 {::proof/from [0]}
+                      2 {::proof/from [0]}}}
+      {::proof/current-problem 2
+       ::proof/premises {0 {::proof/formula ::formula/bottom
+                            ::proof/justification ::proof/assertion}
+                         1 {::proof/formula ["!A"]
+                            ::proof/justification ::proof/hypothesis}
+                         2 {::proof/formula ["!A"]
+                            ::proof/justification ::proof/proved}}
+       ::proof/problems {0 {::proof/premises [0 2]
+                            ::proof/goal q
+                            ::proof/id 0
+                            ::proof/type ::proof/proof
+                            ::proof/status ::proof/open}
+                         1 {::proof/premises [1]
+                            ::proof/goal ["!A"]
+                            ::proof/id 1
+                            ::proof/status ::proof/closed
+                            ::proof/type   ::proof/assert}
+                         2 {::proof/premises [1]
+                            ::proof/id 2
+                            ::proof/status ::proof/open
+                            ::proof/type   ::proof/proof}}
+       ::proof/edges {0 {::proof/to [1 2]}
+                      1 {::proof/from [0]}
+                      2 {::proof/from [0]}}}
       ))
 
 (deftest test-conjunctive-proof
@@ -287,6 +390,7 @@
          ::proof/premises {}
          ::proof/problems {0 {::proof/premises []
                               ::proof/goal pandq
+                              ::proof/type ::proof/proof
                               ::proof/status ::proof/open
                               ::proof/id 0}}
          ::proof/edges {}}
@@ -295,13 +399,16 @@
          ::proof/problems {2 {::proof/premises []
                               ::proof/goal q
                               ::proof/status ::proof/open
+                              ::proof/type ::proof/proof
                               ::proof/id 2}
                            1 {::proof/premises []
                               ::proof/goal p
+                              ::proof/type ::proof/proof
                               ::proof/status ::proof/open
                               ::proof/id 1}
                            0 {::proof/premises []
                               ::proof/goal pandq
+                              ::proof/type ::proof/proof
                               ::proof/status ::proof/open
                               ::proof/id 0}}
          ::proof/edges {0 {::proof/to [1 2]}
@@ -323,6 +430,7 @@
          ::proof/problems {0 {::proof/premises [0]
                               ::proof/goal porq
                               ::proof/id 0
+                              ::proof/type ::proof/proof
                               ::proof/status ::proof/open}}
          ::proof/edges {}}
         {::proof/current-problem nil
@@ -331,6 +439,7 @@
          ::proof/problems {0 {::proof/premises [0]
                               ::proof/goal porq
                               ::proof/id 0
+                              ::proof/type ::proof/proof
                               ::proof/status ::proof/closed}}
          ::proof/edges {}})))
 
@@ -344,6 +453,7 @@
        ::proof/problems {0 {::proof/premises []
                             ::proof/goal [:not ["!P"]]
                             ::proof/id 0
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/open}}
        ::proof/edges {}}
       {::proof/current-problem 1
@@ -352,10 +462,12 @@
        ::proof/problems {0 {::proof/premises []
                             ::proof/goal [:not ["!P"]]
                             ::proof/id 0
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/open}
                          1 {::proof/premises [0]
                             ::proof/goal ::formula/bottom
                             ::proof/id 1
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/open}}
        ::proof/edges {0 {::proof/to [1]}
                       1 {::proof/from [0]}}}))
@@ -370,6 +482,7 @@
        ::proof/problems {0 {::proof/premises []
                             ::proof/goal '[:forall [?x] ["!P" ?x]]
                             ::proof/id 0
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/open}}
        ::proof/edges {}}
       {::proof/current-problem 1
@@ -377,10 +490,12 @@
        ::proof/problems {0 {::proof/premises []
                             ::proof/goal '[:forall [?x] ["!P" ?x]]
                             ::proof/id 0
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/open}
                          1 {::proof/premises []
                             ::proof/goal '["!P" "b"]
                             ::proof/id 1
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/open}}
        ::proof/edges {0 {::proof/to [1]}
                       1 {::proof/from [0]}}}
@@ -390,6 +505,7 @@
        ::proof/problems {0 {::proof/premises []
                             ::proof/goal '[:forall [?p] [:implies ?p ?p]]
                             ::proof/id 0
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/open}}
        ::proof/edges {}}
       {::proof/current-problem 1
@@ -397,10 +513,12 @@
        ::proof/problems {0 {::proof/premises []
                             ::proof/goal '[:forall [?p] [:implies ?p ?p]]
                             ::proof/id 0
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/open}
                          1 {::proof/premises []
                             ::proof/goal '[:implies "b" "b"]
                             ::proof/id 1
+                            ::proof/type ::proof/proof
                             ::proof/status ::proof/open}}
        ::proof/edges {0 {::proof/to [1]}
                       1 {::proof/from [0]}}}
@@ -413,6 +531,7 @@
                                             [?x]
                                             [:or ["!P" ?x] ["!Q" ?x]]]
                              ::proof/id 0
+                             ::proof/type ::proof/proof
                              ::proof/status ::proof/open}}
        ::proof/edges {}}
 {::proof/current-problem 1
@@ -422,10 +541,12 @@
                                      [?x]
                                      [:or ["!P" ?x] ["!Q" ?x]]]
                       ::proof/id 0
+                      ::proof/type ::proof/proof
                       ::proof/status ::proof/open}
                    1 {::proof/premises []
                       ::proof/goal '[:or ["!P" "b"] ["!Q" "b"]]
                       ::proof/id 1
+                      ::proof/type ::proof/proof
                       ::proof/status ::proof/open}
                    }
  ::proof/edges {0 {::proof/to [1]}
@@ -440,18 +561,21 @@
      ::proof/premises {}
      ::proof/problems {0 {::proof/premises []
                          ::proof/goal '[:exists [?x ?y] ["!P" ?x ?y]]
-                         ::proof/id 0
+                          ::proof/id 0
+                          ::proof/type ::proof/proof
                          ::proof/status ::proof/open}}
      ::proof/edges {}} ["a" "b"]
     {::proof/current-problem 1
      ::proof/premises {}
      ::proof/problems {0 {::proof/premises []
-                         ::proof/goal '[:exists [?x ?y] ["!P" ?x ?y]]
-                         ::proof/id 0
-                         ::proof/status ::proof/open}
+                          ::proof/goal '[:exists [?x ?y] ["!P" ?x ?y]]
+                          ::proof/id 0
+                          ::proof/type ::proof/proof
+                          ::proof/status ::proof/open}
                       1 {::proof/premises []
                          ::proof/goal '["!P" "a" "b"]
                          ::proof/id 1
+                         ::proof/type ::proof/proof
                          ::proof/status ::proof/open}}
      ::proof/edges {0 {::proof/to [1]}
                     1 {::proof/from [0]}}}))
@@ -465,5 +589,33 @@
                                       ::proof/goal
                                       '[:exists [?x ?y] ["!P" ?x ?y]]
                                       ::proof/id 0
+                                      ::proof/type ::proof/proof
                                       ::proof/status ::proof/open}}
                  ::proof/edges {}} '["a" ?z]))))
+
+(deftest test-assert
+  (are [proof formula result]
+      (= (goal/assert proof formula) result)
+      {::proof/current-problem 0
+       ::proof/premises {}
+       ::proof/problems {0 {::proof/premises []
+                            ::proof/goal '["!F" "a"]
+                            ::proof/id 0
+                            ::proof/type ::proof/proof
+                            ::proof/status ::proof/open}}
+       ::proof/edges {}}
+      '[:implies ["p"] ["p"]]
+      {::proof/current-problem 1
+       ::proof/premises {}
+       ::proof/problems {0 {::proof/premises []
+                            ::proof/goal '["!F" "a"]
+                            ::proof/id 0
+                            ::proof/status ::proof/open
+                            ::proof/type ::proof/proof}
+                         1 {::proof/premises []
+                            ::proof/goal '[:implies ["p"] ["p"]]
+                            ::proof/id 1
+                            ::proof/status ::proof/open
+                            ::proof/type ::proof/assert}}
+       ::proof/edges {0 {::proof/to [1]}
+                      1 {::proof/from [0]}}}))


### PR DESCRIPTION
This PR adds support for `assert`. At any point in a proof a new
assertion can be made. This assertion is taken as a new goal. Once it
is proved the asserted formula can then be used as a premise.

Three tests have been added for this functionality. The update broke a
couple other tests which required updates.

This ended up also fixing some of the bugs that are in the todo file.