### PR TITLE
hotfix-existential-elimination-broken

### DIFF
--- a/src/clj/logos/main.clj
+++ b/src/clj/logos/main.clj
@@ -161,7 +161,10 @@
     (one-step proof #'goal/assert :args formula)))
 
 (defn execute-existential-proof [proof substituent-string]
-  (let [substituents (read-string (format "[%s]" substituent-string))]
+  (let [substituents (->> substituent-string
+                          (format "[%s]")
+                          edn/read-string
+                          (map str))]
     (one-step
      proof #'goal/existential-proof :args substituents)))
 

--- a/src/clj/logos/proof/goal.clj
+++ b/src/clj/logos/proof/goal.clj
@@ -149,7 +149,9 @@
     (if (formula/existential? current-goal)
       (let [open-formula (formula/quantified-subformula current-goal)
             vars         (formula/bound-variables current-goal)
-            constant-map (zipmap vars constants)
+            constant-map (->> constants
+                              (map formula/read-formula)
+                              (zipmap vars))
             new-goal     (formula/substitute-free-variables
                           open-formula constant-map)]
         (when (seq (formula/free-variables new-goal))


### PR DESCRIPTION
There was a problem with existential elimination. We weren't treating
the variable substitution and reading the same way as other
substitutional rules.