### PR TITLE
F114BD39-B6D9-4E7E-9AA7-3513D0637583: Replace Dangerous Read Strings

### DIFF
--- a/docs/todos.org
+++ b/docs/todos.org
@@ -32,7 +32,8 @@ CLOSED: [2022-03-28 Mon 23:56]
 :ID:       24F7DEFA-436F-47BB-A6E4-478B14077952
 :END:
 * Version 1                                                              :v1:
-** TODO Add a custom function to parse formulas to s-expressions, read-string is dangerous
+** DONE Add a custom function to parse formulas to s-expressions, read-string is dangerous
+CLOSED: [2022-04-29 Fri 00:57]
 :PROPERTIES:
 :ID:       F114BD39-B6D9-4E7E-9AA7-3513D0637583
 :END:

--- a/src/clj/logos/core.clj
+++ b/src/clj/logos/core.clj
@@ -1,9 +1,11 @@
 (ns logos.core
   (:require [org.httpkit.server       :as server]
+            [clojure.edn              :as edn]
             [clojure.data.json        :as json]
             [clojure.pprint           :as pp]
             [compojure.core           :as compojure]
             [compojure.route          :as route]
+            [logos.formula            :as f]
             [logos.main               :as main]
             [ring.middleware.cors     :as cors]
             [ring.middleware.defaults :as middleware]
@@ -21,7 +23,7 @@
                   slurp
                   json/read-str
                   second
-                  read-string
+                  edn/read-string
                   :body)                ; I have no idea why all this
                                         ; is necessary
         command (get body :command)
@@ -33,7 +35,7 @@
          :body body})
       (catch Exception e
         {:status 400
-         :heades {"Content-Type" "text/json"}
+         :headers {"Content-Type" "text/json"}
          :body (ex-data e)}))))
 
 (defn ^:private start-proof-internal
@@ -79,7 +81,7 @@
                           pp/*print-miser-width* nil
                           pp/*print-right-margin* 60]
                   (with-out-str
-                    (pp/pprint (read-string formula))))]
+                    (pp/pprint (f/read-formula-string formula))))]
     result))
 
 (defn format-formula

--- a/src/clj/logos/main.clj
+++ b/src/clj/logos/main.clj
@@ -22,7 +22,7 @@
               pp/*print-miser-width* nil
               pp/*print-right-margin* 60]
       (with-out-str
-        (pp/pprint (read-string formula))))))
+        (pp/pprint (f/read-formula-string formula))))))
 
 (defn serialize-proof-formulas
   [proof]
@@ -108,7 +108,7 @@
   exception of the case of existential proof. In that case
   it is a list of substituents."
   [raw-proof function & {:keys [args]}]
-  (let [proof (read-string (decode raw-proof))
+  (let [proof (edn/read-string (decode raw-proof))
         new-proof (if (nil? args)
                     (function proof)
                     (function proof args))]

--- a/src/clj/logos/proof/premise.clj
+++ b/src/clj/logos/proof/premise.clj
@@ -70,10 +70,10 @@
   (ensure-premises-relevant proof premise-numbers)
   (let [premise-index (get proof ::proof/premises)
         premise-one   (-> premise-index
-                          (get (read-string (first premise-numbers)))
+                          (get (Integer/parseInt (first premise-numbers)))
                           (get ::proof/formula))
         premise-two   (-> premise-index
-                          (get (read-string (second premise-numbers)))
+                          (get (Integer/parseInt (second premise-numbers)))
                           (get ::proof/formula))]
     (cond (and (formula/implication? premise-one)
                (= (formula/antecedent premise-one) premise-two))
@@ -108,7 +108,7 @@
   (ensure-premises-relevant proof premise-numbers)
   (let [premise-index (get proof ::proof/premises)
         formula       (-> premise-index
-                          (get (read-string (first premise-numbers)))
+                          (get (Integer/parseInt (first premise-numbers)))
                           (get ::proof/formula))]
     (if (formula/conjunction? formula)
       (let [conjuncts (formula/conjuncts formula)
@@ -140,7 +140,7 @@
                           (get ::proof/goal))
         target-premise      (->> premise-numbers
                                  first
-                                 read-string
+                                 Integer/parseInt 
                                  (get premise-index)
                                  ::proof/formula)]
     (if (formula/disjunction? target-premise)
@@ -178,8 +178,8 @@
         problem-index     (get proof ::proof/problems)
         problem           (get problem-index current-prblm-idx)
         premise-index     (get proof ::proof/premises)
-        premise-one-idx   (read-string (first premise-numbers))
-        premise-two-idx   (read-string (second premise-numbers))
+        premise-one-idx   (Integer/parseInt (first premise-numbers))
+        premise-two-idx   (Integer/parseInt (second premise-numbers))
         premise-one       (-> premise-index
                               (get premise-one-idx)
                               (get ::proof/formula))
@@ -218,7 +218,7 @@
   (ensure-premises-relevant proof [(first args)])
   (let [premise-index (get proof ::proof/premises)
         formula       (-> premise-index
-                          (get (read-string (first args)))
+                          (get (Integer/parseInt (first args)))
                           (get ::proof/formula))
         new-constants (map formula/read-formula (rest args))]
     (if (formula/universal? formula)
@@ -254,7 +254,7 @@
   (let [premises (get proof ::proof/premises)
         premise  (->> premise-numbers
                       first
-                      read-string
+                      Integer/parseInt
                       (get premises))
         formula  (get premise ::proof/formula)]
     (if (formula/existential? formula)

--- a/src/cljs/logos/views.cljs
+++ b/src/cljs/logos/views.cljs
@@ -273,7 +273,7 @@
             (clear-all-checkboxes)
             (reset! input-atom "")
             (next-proof command proof)))}
-       "Submit Command"]
+       "Submit"]
       ]]))
 
 (def ep-atom (r/atom ""))
@@ -387,10 +387,11 @@
   [theorems]
   (r/with-let [theorems-hidden? (r/atom true)]
     [:section.section
-     [:span {:class "arrow"
-             :on-click #(swap! theorems-hidden? not)}
+     [:span {:class "arrow"}
       [:font {:size "+2"} "Theorems "]
-      [:font {:color "#209CEE"} (if @theorems-hidden? "show" "hide")]]
+      [:button {:class "button is-info is-inverted is-small"
+                :on-click #(swap! theorems-hidden? not)}
+       (if @theorems-hidden? "show" "hide")]]
      (let [start [:table
                   {:class (str "table" " " (when @theorems-hidden?
                                              "is-hidden"))}

--- a/test/logos/formula_test.clj
+++ b/test/logos/formula_test.clj
@@ -114,3 +114,14 @@
     "[:forall [?x] [\"!P\" ?x]]" '[:forall [?x]
                                    ["!P" ?x]]
     ))
+
+(deftest get-matching-paren-idx
+  (are [string idx result]
+      (= (formula/get-matching-paren-idx string idx) result)
+    "(a b c d e f (g ) (h (i (j))) l m) a b d c e" 0 34
+    ")" 0 nil
+    "(a b c" 0 nil
+    "a b c (1 2 3)" 0 nil
+    "a b c (1 2 3)" 6 13
+    "a b c (1 2 3) a b c" 6 13
+    "a b c (1 2 3) a b c" 7 nil))


### PR DESCRIPTION
This PR replaces any occurrence of read-string that occurrs in the
context of reading a formula with read-formula-string which is a safe
way of parsing a formula string. Additionally it removes all instances
of read-string from the premises file and replaces them with
Integer/parseInt. Finally any reading of an internal edn
representation of a structure has been replaced with edn/read-string.