### PR TITLE
013A20CF-E0DC-47DA-9198-F146E37A0F49: Support equality and fix bug

### DIFF
--- a/docs/todos.org
+++ b/docs/todos.org
@@ -3,7 +3,8 @@
 #+author: Andrew Parisi
 
 * Bugs                                                                 :bugs:
-** TODO Theorem names with spaces break things
+** DONE Theorem names with spaces break things
+CLOSED: [2022-05-08 Sun 14:50]
 :PROPERTIES:
 :ID:       98EDDD2D-56B3-4280-A00F-94C42A56B3C0
 :END:
@@ -47,11 +48,13 @@ CLOSED: [2022-04-30 Sat 16:35]
 :PROPERTIES:
 :ID:       D959DCB7-B4B4-4C17-82C3-7BCA4A3C2E0F
 :END:
-** TODO Support identity
+** DONE Support identity
+CLOSED: [2022-05-08 Sun 14:44]
 :PROPERTIES:
 :ID:       013A20CF-E0DC-47DA-9198-F146E37A0F49
 :END:
-** TODO Fix everything in the [[Bugs]] section
+** DONE Fix everything in the [[Bugs]] section
+CLOSED: [2022-05-08 Sun 14:50]
 :PROPERTIES:
 :ID:       C8E34E31-2C6B-4549-BACA-6F674428AA12
 :END:

--- a/src/clj/logos/formula.clj
+++ b/src/clj/logos/formula.clj
@@ -132,6 +132,15 @@
               {:caused-by `(not (atom? ~atom))}))
     (rest atom)))
 
+;;;;;;;;;;;;
+;;; Equality
+
+(defn equality?
+  [object]
+  (and (atom? object)
+       (= (predicate object) "!equals")
+       (= (count (terms object)) 2)))
+
 ;;;;;;;;;;;
 ;; Negation
 

--- a/src/clj/logos/main.clj
+++ b/src/clj/logos/main.clj
@@ -154,7 +154,9 @@
       "UE"
       (function #'premise/universal-elimination)
       "EE"
-      (function #'premise/existential-elimination))))
+      (function #'premise/existential-elimination)
+      "S"
+      (function #'premise/substitute-equality))))
 
 (defn assert-formula-to-proof [proof formula-string]
   (let [formula (f/read-formula formula-string)]

--- a/src/clj/logos/proof/goal.clj
+++ b/src/clj/logos/proof/goal.clj
@@ -24,6 +24,13 @@
                                          (set/intersection (set premises))
                                          seq))
                                 true
+                                (and (formula/equality? current-goal)
+                                     (-> current-goal
+                                         formula/terms
+                                         set
+                                         count
+                                         (= 1)))
+                                true
                                 :else
                                 false)]
     (if proved?
@@ -187,9 +194,5 @@
         (assoc ::proof/current-problem new-idx
                ::proof/edges new-edges))))
 
-
-
-
-(defn id-reflexivity [proof] nil)
 
 (defn modal-proof [proof] nil)

--- a/src/cljs/logos/events.cljs
+++ b/src/cljs/logos/events.cljs
@@ -45,8 +45,11 @@
 
 (rf/reg-event-fx
  ::fetch-proof-start
- (fn [_ [_ theorem-name formula]]
-   (let [encoded-command (-> "Theorem "
+ (fn [_ [_ raw-theorem-name formula]]
+   (let [theorem-name (-> raw-theorem-name
+                          (string/replace #" " "-")
+                          string/lower-case)
+         encoded-command (-> "Theorem "
                              (str theorem-name " " formula)
                              (gstring/urlEncode "UTF-8"))]
      {:http-xhrio {:uri (str

--- a/src/cljs/logos/views.cljs
+++ b/src/cljs/logos/views.cljs
@@ -284,10 +284,11 @@
 (def conditional-elimination-atom (r/atom ""))
 (def conjunction-elimination-atom (r/atom ""))
 (def disjunction-elimination-atom (r/atom ""))
-(def bottom-introduction-atom (r/atom ""))
+(def bottom-introduction-atom     (r/atom ""))
 (def existential-elimination-atom (r/atom ""))
-(def assert-atom (r/atom ""))
-(def universal-elimination-atom (r/atom ""))
+(def substitute-equality-atom     (r/atom ""))
+(def assert-atom                  (r/atom ""))
+(def universal-elimination-atom   (r/atom ""))
 
 (defn next-command-section
   [proof-formulas proof-string proof]
@@ -372,6 +373,13 @@
                bottom-introduction-atom false
                "Open a dialog box to select a premise and its negation.
                Bottom is added to the premises as a result."]
+              ["Substitute Equality" "substitute-equality" "S"
+               substitute-equality-atom true
+               "Open a dialog box to select an equality,
+                an atomic formula to make a substitution in, and
+                specify the arguments (as numbers) to make the 
+                substitutions in. The result is a new premise that 
+                looks like the atom with substitutions made."]
               ["Universal Elimination" "universal-elim" "UE"
                universal-elimination-atom true
                "Open a dialog box to select a universal premise and

--- a/test/logos/proof_goal_test.clj
+++ b/test/logos/proof_goal_test.clj
@@ -143,7 +143,7 @@
 (deftest test-direct-proof
   (are [proof result]
       (= (goal/direct-proof proof)
-         result)
+        result)
     ;; Case 1
       assertion-hypothesis-proof
       {::proof/current-problem nil
@@ -380,6 +380,20 @@
        ::proof/edges {0 {::proof/to [1 2]}
                       1 {::proof/from [0]}
                       2 {::proof/from [0]}}}
+
+      ;; Case 8
+      {::proof/current-problem 0
+       ::proof/problems {0 (proof/new-problem [] ["!equals" "a" "a"] 0)}
+       ::proof/premises {}
+       ::proof/edges  {}}
+      {::proof/current-problem nil
+       ::proof/problems {0 {::proof/premises []
+                            ::proof/goal ["!equals" "a" "a"]
+                            ::proof/id 0
+                            ::proof/status ::proof/closed
+                            ::proof/type ::proof/proof}}
+       ::proof/premises {}
+       ::proof/edges  {}}
       ))
 
 (deftest test-conjunctive-proof

--- a/test/logos/proof_premise_test.clj
+++ b/test/logos/proof_premise_test.clj
@@ -304,3 +304,18 @@
      ::proof/problems {0
                        (proof/new-problem [0 1] ["!Q"] 0)}
      ::proof/edges {}}))
+
+(deftest test-equality-substitution
+  (are [proof args result]
+      (= (premise/substitute-equality proof args) result)
+    {::proof/current-problem 0
+     ::proof/premises {0 (proof/new-premise '["!equals" "a" "b"])
+                       1 (proof/new-premise '["!R" "a" "c"])}
+     ::proof/problems {0 (proof/new-problem [0 1] '["!R" "b" "c"] 0)}
+     ::proof/edges    {}} ["0" "1" "1"]
+    {::proof/current-problem 0
+     ::proof/premises {0 (proof/new-premise '["!equals" "a" "b"])
+                       1 (proof/new-premise '["!R" "a" "c"])
+                       2 (proof/new-premise '["!R" "b" "c"] [1 0])}
+     ::proof/problems {0 (proof/new-problem [0 1 2] '["!R" "b" "c"] 0)}
+     ::proof/edges    {}}))


### PR DESCRIPTION
This PR does two things:

1. It adds support for an equality predicate "!equals"

2. It fixes a bug where the theorem name a user inputs could not have
any spaces in it.